### PR TITLE
Automatically generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,7 +15,7 @@ changelog:
     - title: Bug Fixes 🐛
       labels:
         - bug
-    - title: Maintenance `:gear:`
+    - title: Maintenance 🔧
       labels:
         - chore
     - title: Other Changes

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,12 +7,17 @@ changelog:
   categories:
     - title: Breaking Changes 🛠
       labels:
-        - Semver-Major
         - breaking-change
     - title: Exciting New Features 🎉
       labels:
-        - Semver-Minor
         - enhancement
+        - feature
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Maintenance `:gear:`
+      labels:
+        - chore
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: Release
 
-
 on:
   push:
-    branches: ["feature/release-notes"]
-
+    branches: ["main"]
 
 jobs:
 
@@ -250,20 +248,18 @@ jobs:
 
       # Build github release
       - name: Build release version
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ needs.check-version.outputs.version }}
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: ${{ needs.check-version.outputs.version }}
           prerelease: false
-          title: Release ${{ needs.check-version.outputs.version }}
+          name: Release ${{ needs.check-version.outputs.version }}
+          generate_release_notes: true
       - name: Build release latest
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: latest
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: latest
           prerelease: false
-          title: Latest Release ${{ needs.check-version.outputs.version }}
-      - name: Build changelog
-
-
-        
+          name: Latest Release ${{ needs.check-version.outputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,28 @@
 name: Release
 
+
 on:
   push:
-    branches: ["main"]
+    branches: ["feature/release-notes"]
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"
 
 jobs:
 
@@ -261,3 +281,7 @@ jobs:
           automatic_release_tag: latest
           prerelease: false
           title: Latest Release ${{ needs.check-version.outputs.version }}
+      - name: Build changelog
+
+
+        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,24 +5,6 @@ on:
   push:
     branches: ["feature/release-notes"]
 
-changelog:
-  exclude:
-    labels:
-      - ignore-for-release
-    authors:
-      - octocat
-  categories:
-    - title: Breaking Changes 🛠
-      labels:
-        - Semver-Major
-        - breaking-change
-    - title: Exciting New Features 🎉
-      labels:
-        - Semver-Minor
-        - enhancement
-    - title: Other Changes
-      labels:
-        - "*"
 
 jobs:
 

--- a/helm/vitalam-service-template/Chart.yaml
+++ b/helm/vitalam-service-template/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vitalam-service-template
-appVersion: '0.0.2'
+appVersion: '0.0.3'
 description: A Helm chart for vitalam-service-template
-version: '0.0.2'
+version: '0.0.3'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/vitalam-service-template/values.yaml
+++ b/helm/vitalam-service-template/values.yaml
@@ -3,5 +3,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/vitalam-service-template
   pullPolicy: IfNotPresent
-  tag: 'v0.0.2'
+  tag: 'v0.0.3'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/vitalam-service-template",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/vitalam-service-template",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/vitalam-service-template",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Service for VITALam",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Uses the new [automatic release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) GitHub feature to generate release notes, aka `changelog`, based on PR labels. 

**There will be a separate PR to finalise the labels we want to use and add them to `CONTRIBUTING.md`.** This PR is to test that automated release note generation is working.

- [x] `release.yml` for changelog config, not to be confused with our existing `release.yml` workflow (change name of this?)
- [x] use a different publish release [action](https://github.com/softprops/action-gh-release). The previous action has yet to add automatic release notes, [see here](https://github.com/marvinpinto/actions/issues/312).
