### PR TITLE
Replace rather than update latest release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,13 @@ jobs:
           charts_dir: helm
 
       # Build github release
+      - name: Delete latest release
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { owner, repo } = context.repo
+            await github.rest.git.deleteRef({ owner, repo, ref: 'tags/latest' })
       - name: Build release version
         uses: softprops/action-gh-release@v1
         with:

--- a/helm/vitalam-service-template/Chart.yaml
+++ b/helm/vitalam-service-template/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vitalam-service-template
-appVersion: '0.0.4'
+appVersion: '0.0.5'
 description: A Helm chart for vitalam-service-template
-version: '0.0.4'
+version: '0.0.5'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/vitalam-service-template/values.yaml
+++ b/helm/vitalam-service-template/values.yaml
@@ -3,5 +3,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/vitalam-service-template
   pullPolicy: IfNotPresent
-  tag: 'v0.0.4'
+  tag: 'v0.0.5'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/vitalam-service-template",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/vitalam-service-template",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/vitalam-service-template",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Service for VITALam",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Uses [github-script](https://github.com/actions/github-script) to delete `tags/latest` so we get a new `latest` release that matches our most recent release.

Example (I've since deleted these releases):
![image](https://user-images.githubusercontent.com/40722025/150336676-e15d2dcf-ad85-4bad-bf8a-dc92d15e81b1.png)

![image](https://user-images.githubusercontent.com/40722025/150336611-cfbd3c38-af1b-48bd-893b-056c4f45d2e9.png)
