### PR TITLE
Handle 422 on delete latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,12 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo } = context.repo
-            await github.rest.git.deleteRef({ owner, repo, ref: 'tags/latest' })
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: 'tags/latest' })
+            }
+            catch (err) {
+              if (err.status !== 422) throw err
+            } 
       - name: Build release version
         uses: softprops/action-gh-release@v1
         with:

--- a/helm/vitalam-service-template/Chart.yaml
+++ b/helm/vitalam-service-template/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vitalam-service-template
-appVersion: '0.0.5'
+appVersion: '0.0.6'
 description: A Helm chart for vitalam-service-template
-version: '0.0.5'
+version: '0.0.6'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/vitalam-service-template/values.yaml
+++ b/helm/vitalam-service-template/values.yaml
@@ -3,5 +3,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/vitalam-service-template
   pullPolicy: IfNotPresent
-  tag: 'v0.0.5'
+  tag: 'v0.0.6'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/vitalam-service-template",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/vitalam-service-template",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/vitalam-service-template",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Service for VITALam",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Ignores when `await github.rest.git.deleteRef({ owner, repo, ref: 'tags/latest' })` throws a 422 error (because there's no latest tag)